### PR TITLE
Überflüssiges keyword entfernt

### DIFF
--- a/worblehat-domain/src/main/java/de/codecentric/psd/worblehat/domain/BorrowingRepository.java
+++ b/worblehat-domain/src/main/java/de/codecentric/psd/worblehat/domain/BorrowingRepository.java
@@ -9,7 +9,7 @@ import java.util.List;
 public interface BorrowingRepository extends JpaRepository<Borrowing, Long> {
 
     @Query("SELECT b from Borrowing b WHERE b.borrowedBook = :book")
-    public Borrowing findBorrowingForBook(@Param("book") Book book);
+    Borrowing findBorrowingForBook(@Param("book") Book book);
 
     @Query("SELECT b from Borrowing b WHERE b.borrowerEmailAddress = :borrowerEmailAddress")
     List<Borrowing> findBorrowingsByBorrower(@Param("borrowerEmailAddress") String borrowerEmailAddress);


### PR DESCRIPTION
In einem Interface sind Methoden (wenn nicht anders angegeben) public.