### PR TITLE
Refactor Spring Data JPA finder via Query Creation

### DIFF
--- a/worblehat-domain/src/main/java/de/codecentric/psd/worblehat/domain/BorrowingRepository.java
+++ b/worblehat-domain/src/main/java/de/codecentric/psd/worblehat/domain/BorrowingRepository.java
@@ -5,11 +5,11 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface BorrowingRepository extends JpaRepository<Borrowing, Long> {
 
-    @Query("SELECT b from Borrowing b WHERE b.borrowedBook = :book")
-    Borrowing findBorrowingForBook(@Param("book") Book book);
+    Optional<Borrowing> findByBorrowedBook(Book book);
 
     @Query("SELECT b from Borrowing b WHERE b.borrowerEmailAddress = :borrowerEmailAddress")
     List<Borrowing> findBorrowingsByBorrower(@Param("borrowerEmailAddress") String borrowerEmailAddress);

--- a/worblehat-domain/src/test/java/de/codecentric/psd/worblehat/domain/StandardBookServiceTest.java
+++ b/worblehat-domain/src/test/java/de/codecentric/psd/worblehat/domain/StandardBookServiceTest.java
@@ -72,7 +72,7 @@ class StandardBookServiceTest {
         when(borrowingRepository.findBorrowingsByBorrower(BORROWER_EMAIL))
                 .thenReturn(Arrays.asList(aBorrowing, anotherBorrowing));
 
-        when(borrowingRepository.findBorrowingForBook(aBook)).thenReturn(null);
+        when(borrowingRepository.findByBorrowedBook(aBook)).thenReturn(Optional.empty());
 
         bookService = new StandardBookService(borrowingRepository, bookRepository);
     }


### PR DESCRIPTION
Spring Data JPA kann aus dem Methodennamen die JPA Query ableiten.
Siehe https://docs.spring.io/spring-data/jpa/docs/current/reference/html/#repositories.query-methods.query-creation

Außerdem unterstüzt Spring Data JPA als Rückgabetyp `java.util.Optional`.
Das umgeht dann die Rückgabe von `null`.

Btw: Die konkrete Methode wird bisher nur in einem Test benutzt. Altlast
oder for future use?