### PR TITLE
Entfernt obsoletes @Autowired in Spring Controller

### DIFF
--- a/worblehat-domain/src/main/java/de/codecentric/psd/worblehat/domain/StandardBookService.java
+++ b/worblehat-domain/src/main/java/de/codecentric/psd/worblehat/domain/StandardBookService.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -15,14 +16,9 @@ import java.util.Set;
 @Transactional
 public class StandardBookService implements BookService {
 
-    public StandardBookService() {
-
-    }
-
-    @Autowired
     public StandardBookService(BorrowingRepository borrowingRepository, BookRepository bookRepository) {
-        this.borrowingRepository = borrowingRepository;
-        this.bookRepository = bookRepository;
+        this.borrowingRepository = Objects.requireNonNull(borrowingRepository);
+        this.bookRepository = Objects.requireNonNull(bookRepository);
     }
 
     private BorrowingRepository borrowingRepository;

--- a/worblehat-domain/src/main/java/de/codecentric/psd/worblehat/domain/StandardBookService.java
+++ b/worblehat-domain/src/main/java/de/codecentric/psd/worblehat/domain/StandardBookService.java
@@ -1,11 +1,11 @@
 package de.codecentric.psd.worblehat.domain;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -14,16 +14,14 @@ import java.util.Set;
  */
 @Service
 @Transactional
+@RequiredArgsConstructor
 public class StandardBookService implements BookService {
 
-    public StandardBookService(BorrowingRepository borrowingRepository, BookRepository bookRepository) {
-        this.borrowingRepository = Objects.requireNonNull(borrowingRepository);
-        this.bookRepository = Objects.requireNonNull(bookRepository);
-    }
+    @NonNull
+    private final BorrowingRepository borrowingRepository;
 
-    private BorrowingRepository borrowingRepository;
-
-    private BookRepository bookRepository;
+    @NonNull
+    private final BookRepository bookRepository;
 
     @Override
     public void returnAllBooksByBorrower(String borrowerEmailAddress) {

--- a/worblehat-web/src/main/java/de/codecentric/psd/worblehat/web/controller/BookListController.java
+++ b/worblehat-web/src/main/java/de/codecentric/psd/worblehat/web/controller/BookListController.java
@@ -2,26 +2,25 @@ package de.codecentric.psd.worblehat.web.controller;
 
 import de.codecentric.psd.worblehat.domain.Book;
 import de.codecentric.psd.worblehat.domain.BookService;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
 import java.util.List;
-import java.util.Objects;
 
 /**
  * Controller class for the book table result.
  */
 @Controller
 @RequestMapping("/bookList")
+@RequiredArgsConstructor
 public class BookListController {
 
+    @NonNull
     private final BookService bookService;
-
-    public BookListController(BookService bookService) {
-        this.bookService = Objects.requireNonNull(bookService);
-    }
 
     @RequestMapping(method = RequestMethod.GET)
     public String setupForm(ModelMap modelMap) {

--- a/worblehat-web/src/main/java/de/codecentric/psd/worblehat/web/controller/BookListController.java
+++ b/worblehat-web/src/main/java/de/codecentric/psd/worblehat/web/controller/BookListController.java
@@ -2,13 +2,13 @@ package de.codecentric.psd.worblehat.web.controller;
 
 import de.codecentric.psd.worblehat.domain.Book;
 import de.codecentric.psd.worblehat.domain.BookService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Controller class for the book table result.
@@ -17,11 +17,10 @@ import java.util.List;
 @RequestMapping("/bookList")
 public class BookListController {
 
-    private BookService bookService;
+    private final BookService bookService;
 
-    @Autowired
     public BookListController(BookService bookService) {
-        this.bookService = bookService;
+        this.bookService = Objects.requireNonNull(bookService);
     }
 
     @RequestMapping(method = RequestMethod.GET)

--- a/worblehat-web/src/main/java/de/codecentric/psd/worblehat/web/controller/BorrowBookController.java
+++ b/worblehat-web/src/main/java/de/codecentric/psd/worblehat/web/controller/BorrowBookController.java
@@ -4,7 +4,6 @@ import de.codecentric.psd.worblehat.domain.Book;
 import de.codecentric.psd.worblehat.domain.BookService;
 import de.codecentric.psd.worblehat.domain.Borrowing;
 import de.codecentric.psd.worblehat.web.formdata.BorrowBookFormData;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.ui.ModelMap;
@@ -16,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -27,11 +27,10 @@ import java.util.Set;
 public class BorrowBookController {
 
     private static final String BORROW_PAGE = "borrow";
-    private BookService bookService;
+    private final BookService bookService;
 
-    @Autowired
     public BorrowBookController(BookService bookService) {
-        this.bookService = bookService;
+        this.bookService = Objects.requireNonNull(bookService);
     }
 
     @RequestMapping(method = RequestMethod.GET)

--- a/worblehat-web/src/main/java/de/codecentric/psd/worblehat/web/controller/BorrowBookController.java
+++ b/worblehat-web/src/main/java/de/codecentric/psd/worblehat/web/controller/BorrowBookController.java
@@ -4,6 +4,8 @@ import de.codecentric.psd.worblehat.domain.Book;
 import de.codecentric.psd.worblehat.domain.BookService;
 import de.codecentric.psd.worblehat.domain.Borrowing;
 import de.codecentric.psd.worblehat.web.formdata.BorrowBookFormData;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.ui.ModelMap;
@@ -15,7 +17,6 @@ import org.springframework.web.bind.annotation.RequestMethod;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -24,17 +25,16 @@ import java.util.Set;
  */
 @RequestMapping("/borrow")
 @Controller
+@RequiredArgsConstructor
 public class BorrowBookController {
 
     private static final String BORROW_PAGE = "borrow";
+
+    @NonNull
     private final BookService bookService;
 
-    public BorrowBookController(BookService bookService) {
-        this.bookService = Objects.requireNonNull(bookService);
-    }
-
     @RequestMapping(method = RequestMethod.GET)
-    public void setupForm(final ModelMap model) {
+    public void setupForm(ModelMap model) {
         model.put("borrowFormData", new BorrowBookFormData());
     }
 

--- a/worblehat-web/src/main/java/de/codecentric/psd/worblehat/web/controller/InsertBookController.java
+++ b/worblehat-web/src/main/java/de/codecentric/psd/worblehat/web/controller/InsertBookController.java
@@ -3,6 +3,8 @@ package de.codecentric.psd.worblehat.web.controller;
 import de.codecentric.psd.worblehat.domain.Book;
 import de.codecentric.psd.worblehat.domain.BookService;
 import de.codecentric.psd.worblehat.web.formdata.InsertBookFormData;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Controller;
@@ -13,7 +15,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
 import javax.validation.Valid;
-import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -21,15 +22,13 @@ import java.util.Optional;
  */
 @Controller
 @RequestMapping("/insertBooks")
+@RequiredArgsConstructor
 public class InsertBookController {
 
     private static final Logger LOG = LoggerFactory.getLogger(InsertBookController.class);
 
+    @NonNull
     private final BookService bookService;
-
-    public InsertBookController(BookService bookService) {
-        this.bookService = Objects.requireNonNull(bookService);
-    }
 
     @RequestMapping(method = RequestMethod.GET)
     public void setupForm(ModelMap modelMap) {

--- a/worblehat-web/src/main/java/de/codecentric/psd/worblehat/web/controller/InsertBookController.java
+++ b/worblehat-web/src/main/java/de/codecentric/psd/worblehat/web/controller/InsertBookController.java
@@ -5,7 +5,6 @@ import de.codecentric.psd.worblehat.domain.BookService;
 import de.codecentric.psd.worblehat.web.formdata.InsertBookFormData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
 import org.springframework.validation.BindingResult;
@@ -14,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
 import javax.validation.Valid;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -23,14 +23,12 @@ import java.util.Optional;
 @RequestMapping("/insertBooks")
 public class InsertBookController {
 
-
     private static final Logger LOG = LoggerFactory.getLogger(InsertBookController.class);
 
-    private BookService bookService;
+    private final BookService bookService;
 
-    @Autowired
     public InsertBookController(BookService bookService) {
-        this.bookService = bookService;
+        this.bookService = Objects.requireNonNull(bookService);
     }
 
     @RequestMapping(method = RequestMethod.GET)

--- a/worblehat-web/src/main/java/de/codecentric/psd/worblehat/web/controller/ReturnAllBooksController.java
+++ b/worblehat-web/src/main/java/de/codecentric/psd/worblehat/web/controller/ReturnAllBooksController.java
@@ -2,6 +2,8 @@ package de.codecentric.psd.worblehat.web.controller;
 
 import de.codecentric.psd.worblehat.domain.BookService;
 import de.codecentric.psd.worblehat.web.formdata.ReturnAllBooksFormData;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
 import org.springframework.validation.BindingResult;
@@ -10,20 +12,17 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
 import javax.validation.Valid;
-import java.util.Objects;
 
 /**
  * Controller class for the
  */
 @Controller
 @RequestMapping("/returnAllBooks")
+@RequiredArgsConstructor
 public class ReturnAllBooksController {
 
+    @NonNull
     private final BookService bookService;
-
-    public ReturnAllBooksController(BookService bookService) {
-        this.bookService = Objects.requireNonNull(bookService);
-    }
 
     @RequestMapping(method = RequestMethod.GET)
     public void prepareView(ModelMap modelMap) {

--- a/worblehat-web/src/main/java/de/codecentric/psd/worblehat/web/controller/ReturnAllBooksController.java
+++ b/worblehat-web/src/main/java/de/codecentric/psd/worblehat/web/controller/ReturnAllBooksController.java
@@ -2,7 +2,6 @@ package de.codecentric.psd.worblehat.web.controller;
 
 import de.codecentric.psd.worblehat.domain.BookService;
 import de.codecentric.psd.worblehat.web.formdata.ReturnAllBooksFormData;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
 import org.springframework.validation.BindingResult;
@@ -11,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
 import javax.validation.Valid;
+import java.util.Objects;
 
 /**
  * Controller class for the
@@ -19,11 +19,10 @@ import javax.validation.Valid;
 @RequestMapping("/returnAllBooks")
 public class ReturnAllBooksController {
 
-    private BookService bookService;
+    private final BookService bookService;
 
-    @Autowired
     public ReturnAllBooksController(BookService bookService) {
-        this.bookService = bookService;
+        this.bookService = Objects.requireNonNull(bookService);
     }
 
     @RequestMapping(method = RequestMethod.GET)


### PR DESCRIPTION
Wenn die Bean nur einen Konstuktor hat, kann die Annotation `@Autowired`
entfallen für Injection.
Siehe https://docs.spring.io/spring-boot/docs/current/reference/html/using-boot-spring-beans-and-dependency-injection.html

Die Prüfung der Abhängigkeiten auf `null` in den Konstruktoren soll "fail
fast" unterstützen, damit nicht erst bei Verwendung eine NPE fliegt.

Außerdem habe ich die Felder `final` gesetzt.