### PR TITLE
Refactor controller test mit Mockito annotations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,11 @@
                 <version>2.19.0</version>
             </dependency>
             <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-junit-jupiter</artifactId>
+                <version>2.19.0</version>
+            </dependency>
+            <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-engine</artifactId>
                 <version>5.2.0</version>

--- a/worblehat-web/pom.xml
+++ b/worblehat-web/pom.xml
@@ -74,6 +74,16 @@
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/worblehat-web/src/test/java/de/codecentric/psd/worblehat/web/controller/BookListControllerTest.java
+++ b/worblehat-web/src/test/java/de/codecentric/psd/worblehat/web/controller/BookListControllerTest.java
@@ -4,6 +4,9 @@ import de.codecentric.psd.worblehat.domain.Book;
 import de.codecentric.psd.worblehat.domain.BookService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoSettings;
 import org.springframework.ui.ModelMap;
 
 import java.util.ArrayList;
@@ -11,35 +14,35 @@ import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@MockitoSettings
 class BookListControllerTest {
 
-    private BookService bookService;
-
+    @InjectMocks
     private BookListController bookListController;
+
+    @Mock
+    private BookService bookService;
 
     private static final Book TEST_BOOK = new Book("title", "author", "edition", "isbn", 2016);
 
     private ModelMap modelMap;
 
     @BeforeEach
-    void setUp() throws Exception {
-        bookService = mock(BookService.class);
-        bookListController = new BookListController(bookService);
+    void setUp() {
         modelMap = new ModelMap();
     }
 
     @Test
-    void shouldNavigateToBookList() throws Exception {
+    void shouldNavigateToBookList() {
         String url = bookListController.setupForm(modelMap);
         assertThat(url, is("bookList"));
     }
 
     @Test
-    void shouldContainBooks() throws Exception {
-        List<Book> bookList = new ArrayList();
+    void shouldContainBooks() {
+        List<Book> bookList = new ArrayList<>();
         bookList.add(TEST_BOOK);
         when(bookService.findAllBooks()).thenReturn(bookList);
         bookListController.setupForm(modelMap);


### PR DESCRIPTION
Einführung der Dependency mockito-junit-jupiter.
Damit kann die Annotation `@MockitoSettings` verwendet werden.
Dadurch müssen die Mocks nicht mehr manuell erzeugt werden, sondern
können per Annotation deklariert werden.
Siehe https://solidsoft.wordpress.com/2018/03/27/convenient-mocking-in-mockito-with-junit-5-the-official-way/

Außerdem habe ich obsolete `throws`-Klauseln entfernt.