### PR TITLE
Detailseite für Bücher (je ISBN) hinzugefügt (#12).

### DIFF
--- a/worblehat-acceptancetests/src/main/java/de/codecentric/worblehat/acceptancetests/adapter/SeleniumAdapter.java
+++ b/worblehat-acceptancetests/src/main/java/de/codecentric/worblehat/acceptancetests/adapter/SeleniumAdapter.java
@@ -56,7 +56,16 @@ public class SeleniumAdapter {
     }
 
     public void gotoPage(Page page) {
-        String concreteUrl = Config.getApplicationURL() + "/" + page.getUrl();
+        goToUrl(page.getUrl());
+    }
+
+    public void gotoPageWithParameter(Page page, String parameter) {
+        String url = page.getUrl(parameter);
+        goToUrl(url);
+    }
+
+    private void goToUrl(String url) {
+        String concreteUrl = Config.getApplicationURL() + "/" + url;
         driver.get(concreteUrl);
     }
 
@@ -110,5 +119,9 @@ public class SeleniumAdapter {
             LOGGER.error("Could not take screenshot!", e);
         }
 
+    }
+
+    public boolean containsTextOnPage(String text) {
+        return driver.getPageSource().contains(text);
     }
 }

--- a/worblehat-acceptancetests/src/main/java/de/codecentric/worblehat/acceptancetests/adapter/wrapper/Page.java
+++ b/worblehat-acceptancetests/src/main/java/de/codecentric/worblehat/acceptancetests/adapter/wrapper/Page.java
@@ -4,7 +4,8 @@ public enum Page {
     BOOKLIST("bookList"),
     INSERTBOOKS("insertBooks"),
     BORROWBOOK("borrow"),
-    RETURNBOOKS("returnAllBooks");
+    RETURNBOOKS("returnAllBooks"),
+    BOOKDETAILS("bookDetails?isbn=%s");
 
     private String url;
 
@@ -14,5 +15,9 @@ public enum Page {
 
     public String getUrl() {
         return url;
+    }
+
+    public String getUrl(String parameter) {
+        return String.format(url, parameter);
     }
 }

--- a/worblehat-acceptancetests/src/main/java/de/codecentric/worblehat/acceptancetests/step/page/BookDetailsPage.java
+++ b/worblehat-acceptancetests/src/main/java/de/codecentric/worblehat/acceptancetests/step/page/BookDetailsPage.java
@@ -1,0 +1,52 @@
+package de.codecentric.worblehat.acceptancetests.step.page;
+
+import de.codecentric.psd.worblehat.domain.Book;
+import de.codecentric.psd.worblehat.domain.BookService;
+import de.codecentric.worblehat.acceptancetests.adapter.SeleniumAdapter;
+import de.codecentric.worblehat.acceptancetests.adapter.wrapper.Page;
+import de.codecentric.worblehat.acceptancetests.step.StoryContext;
+import org.jbehave.core.annotations.Then;
+import org.jbehave.core.annotations.When;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+
+@Component("DetailPage")
+public class BookDetailsPage {
+
+    private SeleniumAdapter seleniumAdapter;
+    private StoryContext storyContext;
+    private BookService bookService;
+
+    @Autowired
+    public BookDetailsPage(SeleniumAdapter seleniumAdapter, StoryContext storyContext, BookService bookService) {
+        this.seleniumAdapter = seleniumAdapter;
+        this.storyContext = storyContext;
+        this.bookService = bookService;
+    }
+
+    @When("I navigate to the detail page of the book with the isbn $isbn")
+    public void navigateToDetailPage(String isbn) {
+        seleniumAdapter.gotoPageWithParameter(Page.BOOKDETAILS, isbn);
+        storyContext.put("LAST_BROWSED_BOOK_DETAILS", isbn);
+    }
+
+    @Then("I can see all book details for that book")
+    public void allBookDetailsVisible() {
+        String isbn = storyContext.get("LAST_BROWSED_BOOK_DETAILS");
+        Set<Book> books = bookService.findBooksByIsbn(isbn);
+        assertThat(books, hasSize(greaterThanOrEqualTo(1)));
+        Book next = books.iterator().next();
+        assertThat(seleniumAdapter.containsTextOnPage(next.getIsbn()), is(true));
+        assertThat(seleniumAdapter.containsTextOnPage(next.getAuthor()), is(true));
+        assertThat(seleniumAdapter.containsTextOnPage(next.getDescription()), is(true));
+        assertThat(seleniumAdapter.containsTextOnPage(next.getTitle()), is(true));
+        assertThat(seleniumAdapter.containsTextOnPage(next.getEdition()), is(true));
+        assertThat(seleniumAdapter.containsTextOnPage(String.valueOf(next.getYearOfPublication())), is(true));
+    }
+}

--- a/worblehat-acceptancetests/src/main/java/de/codecentric/worblehat/acceptancetests/step/page/BookList.java
+++ b/worblehat-acceptancetests/src/main/java/de/codecentric/worblehat/acceptancetests/step/page/BookList.java
@@ -7,6 +7,7 @@ import de.codecentric.worblehat.acceptancetests.adapter.wrapper.HtmlBookList;
 import de.codecentric.worblehat.acceptancetests.adapter.wrapper.Page;
 import de.codecentric.worblehat.acceptancetests.adapter.wrapper.PageElement;
 import de.codecentric.worblehat.acceptancetests.step.business.DemoBookFactory;
+import org.jbehave.core.annotations.Given;
 import org.jbehave.core.annotations.Then;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -29,6 +30,11 @@ public class BookList {
     @Autowired
     public BookList(SeleniumAdapter seleniumAdapter) {
         this.seleniumAdapter = seleniumAdapter;
+    }
+
+    @Given("I browse the list of all books")
+    public void browseBookList() {
+        seleniumAdapter.gotoPage(Page.BOOKLIST);
     }
 
     @Then("the booklist contains a book with values title $title, author $author, year $year, edition $edition, isbn $isbn")

--- a/worblehat-acceptancetests/src/main/resources/de/codecentric/worblehat/acceptancetests/stories/book/Book Details.story
+++ b/worblehat-acceptancetests/src/main/resources/de/codecentric/worblehat/acceptancetests/stories/book/Book Details.story
@@ -1,0 +1,19 @@
+Meta:
+@themes Book
+
+Narrative:
+In order to find an interesting book
+as a user of the library
+I want to see more details about books
+
+Scenario:
+
+Given a library, containing a book with isbn <isbn>
+And I browse the list of all books
+When I navigate to the detail page of the book with the isbn <isbn>
+Then I can see all book details for that book
+
+Examples:
+
+| isbn       |
+| 0552131075 |

--- a/worblehat-web/src/main/java/de/codecentric/psd/worblehat/web/controller/BookDetailsController.java
+++ b/worblehat-web/src/main/java/de/codecentric/psd/worblehat/web/controller/BookDetailsController.java
@@ -1,0 +1,36 @@
+package de.codecentric.psd.worblehat.web.controller;
+
+import de.codecentric.psd.worblehat.domain.Book;
+import de.codecentric.psd.worblehat.domain.BookService;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.ModelMap;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.Set;
+
+@Controller
+@RequestMapping("/bookDetails")
+@RequiredArgsConstructor
+public class BookDetailsController {
+    private static final String BOOK_DETAILS = "bookDetails";
+
+    private static final String REDIRECT_TO_BOOK_LIST = "redirect:bookList";
+
+    @NonNull
+    private final BookService bookService;
+
+    @RequestMapping(method = RequestMethod.GET)
+    public String setupForm(ModelMap modelMap, @RequestParam String isbn) {
+        Set<Book> books = bookService.findBooksByIsbn(isbn);
+        if (books.isEmpty()) {
+            return REDIRECT_TO_BOOK_LIST;
+        }
+        Book book = books.iterator().next();
+        modelMap.addAttribute("book", book);
+        return BOOK_DETAILS;
+    }
+}

--- a/worblehat-web/src/main/resources/templates/bookDetails.html
+++ b/worblehat-web/src/main/resources/templates/bookDetails.html
@@ -1,0 +1,38 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>Worblehat Bookmanager</title>
+</head>
+<body>
+<h1><span th:text="${book.title}"></span></h1>
+
+<table>
+    <tr>
+        <td>ISBN:</td>
+        <td th:text="${book.isbn}">ISBN</td>
+    </tr>
+    <tr>
+        <td>Author:</td>
+        <td th:text="${book.author}">Author</td>
+    </tr>
+    <tr>
+        <td>Year:</td>
+        <td th:text="${book.yearOfPublication}">Year</td>
+    </tr>
+    <tr>
+        <td>Edition:</td>
+        <td th:text="${book.edition}">Year</td>
+    </tr>
+    <tr>
+        <td colspan="2">Description:</td>
+    </tr>
+    <tr>
+        <td colspan="2" th:text="${book.description}">Description</td>
+    </tr>
+</table>
+<footer>
+    <div th:replace="fragments/footer :: subpage-footer">Footer</div>
+</footer>
+
+</body>
+</html>

--- a/worblehat-web/src/main/resources/templates/bookList.html
+++ b/worblehat-web/src/main/resources/templates/bookList.html
@@ -14,6 +14,7 @@
 			<th>ISBN</th>
 			<th>Description</th>
 			<th>Borrower</th>
+			<th>Details</th>
 		</tr>
 	</thead>
 	<tbody>
@@ -25,6 +26,7 @@
 			<td th:text="${book.isbn}">123456</td>
 			<td style="white-space: pre-wrap;" th:text="${book.description}">Description</td>
 			<td th:text="${book?.borrowing?.borrowerEmailAddress}">someone@codecentric.de</td>
+			<td><a th:href="@{/bookDetails(isbn=${book.isbn})}">Details</a></td>
 		</tr>
 	</tbody>
 	</table>

--- a/worblehat-web/src/test/java/de/codecentric/psd/worblehat/web/controller/BookDetailsControllerTest.java
+++ b/worblehat-web/src/test/java/de/codecentric/psd/worblehat/web/controller/BookDetailsControllerTest.java
@@ -1,0 +1,50 @@
+package de.codecentric.psd.worblehat.web.controller;
+
+import com.google.common.collect.ImmutableSet;
+import de.codecentric.psd.worblehat.domain.Book;
+import de.codecentric.psd.worblehat.domain.BookService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.springframework.ui.ModelMap;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.when;
+
+@MockitoSettings
+public class BookDetailsControllerTest {
+
+    @InjectMocks
+    private BookDetailsController bookDetailsController;
+
+    @Mock
+    private BookService bookService;
+
+    private ModelMap modelMap;
+
+    public static final String ISBN = "123456789X";
+    private static final Book TEST_BOOK = new Book("title", "author", "edition", "isbn", 2016);
+
+    @BeforeEach
+    void setUp() {
+        modelMap = new ModelMap();
+        when(bookService.findBooksByIsbn(ISBN)).thenReturn(ImmutableSet.of(TEST_BOOK));
+    }
+
+    @Test
+    void shouldNavigateToBookDetails() {
+        String url = bookDetailsController.setupForm(modelMap, ISBN);
+        assertThat(url, containsString("bookDetails"));
+    }
+
+    @Test
+    void shouldContainBookDetails() {
+        bookDetailsController.setupForm(modelMap, ISBN);
+        Book actualBook = (Book) modelMap.get("book");
+        assertThat(actualBook, is(TEST_BOOK));
+    }
+}


### PR DESCRIPTION
Analog zu #47 fügt dieser Branch eine Detailseite hinzu, weicht aber in einigen Annahmen ab:
- Das Buch wird nicht per ID identifiziert, sondern per ISBN, d.h. die Detailseite ist nicht für ein einzelnes Exemplar, sondern für eine Klasse von Exemplaren.
- Es werden die Buchdetails des ersten gefundenen Buches mit der ISBN angezeigt. Es wird angenommen, dass der Bibliothekar sorgfältig arbeitet (wie in #12 beschrieben).

Es wurde angenommen, dass der Aufruf einer Detailseite zu einer nicht existierenden ISBN zu einer Weiterleitung zur Buchliste führt, statt eine Fehlermeldung anzuzeigen. Außerdem gibt es in diesem Branch kein Cover.