### PR TITLE
java.sql.SQLFeatureNotSupportedException verhindern

### DIFF
--- a/worblehat-web/src/main/resources/application.properties
+++ b/worblehat-web/src/main/resources/application.properties
@@ -15,4 +15,5 @@ logging.file=/tmp/@pom.artifactId@.log
 spring.liquibase.change-log=classpath:master.xml
 spring.liquibase.drop-first=true
 spring.jpa.hibernate.ddl-auto=validate
+spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
 spring.thymeleaf.cache=false


### PR DESCRIPTION
Die Exception java.sql.SQLFeatureNotSupportedException wird mit diesem Branch verhindert.